### PR TITLE
Prevent session hijacking

### DIFF
--- a/pyramid_sockjs/tests/test_route.py
+++ b/pyramid_sockjs/tests/test_route.py
@@ -167,7 +167,7 @@ class TestSockJSRoute(BaseSockjs):
             'transport': 'test', 'session': 'session', 'server': '000'}
         res = route.handler(self.request)
 
-        session = route.session_manager['session']
+        session = route.session_manager[(None, 'session')]
         self.assertFalse(route.session_manager.is_acquired(session))
 
         del handlers['test']


### PR DESCRIPTION
In pyramid_sockjs 0.3.5, if an attacker can find out a user's session ID, I believe the session can be hijacked. (The attacker can get the session ID through social engineering or by stealing server logs.)

The patch I am submitting should fix the hole. The patch changes the way pyramid_sockjs identifies sessions; this version looks up sessions by both user ID and session ID, making it impossible for an attacker to access another user's session without logging in as that user. The feature can be disabled by setting per_user=False.
