### PR TITLE
Updated GitHub URL to download a PIP package

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,6 @@ python:
   - 2.6
   - 2.7
 install: 
-  - pip install https://github.com/downloads/SiteSupport/gevent/gevent-1.0rc1.tar.gz
+  - pip install https://github.com/surfly/gevent/archive/1.0rc1.tar.gz
   - python setup.py develop
 script: python setup.py test


### PR DESCRIPTION
GitHub recently changed their URLs, so the `pip install <url>` needed to be updated.
